### PR TITLE
feat(theme): add dynamic light and dark theme support with refactored CSS

### DIFF
--- a/src/main/java/br/com/gzlabs/gzassist/Main.java
+++ b/src/main/java/br/com/gzlabs/gzassist/Main.java
@@ -28,6 +28,7 @@ public class Main extends Application {
         scene.getStylesheets().add(
                 Objects.requireNonNull(getClass().getResource("presentation/style.css")).toExternalForm()
         );
+        scene.getRoot().getStyleClass().add("theme-dark");
         stage.setScene(scene);
         stage.setTitle("GZAssist");
         stage.setResizable(false);

--- a/src/main/java/br/com/gzlabs/gzassist/Main.java
+++ b/src/main/java/br/com/gzlabs/gzassist/Main.java
@@ -4,17 +4,16 @@ import br.com.gzlabs.gzassist.application.AnswerService;
 import br.com.gzlabs.gzassist.application.AppFactory;
 import br.com.gzlabs.gzassist.presentation.HomeController;
 import br.com.gzlabs.gzassist.presentation.OverlayController;
+import br.com.gzlabs.gzassist.util.ThemeManager;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static javafx.scene.paint.Color.web;
 
 public class Main extends Application {
 
@@ -24,11 +23,9 @@ public class Main extends Application {
     @Override
     public void start(Stage stage) throws Exception {
         FXMLLoader loader = new FXMLLoader(Main.class.getResource("presentation/home-view.fxml"));
-        Scene scene = new Scene(loader.load(), 430, 680, web("#181a1b"));
-        scene.getStylesheets().add(
-                Objects.requireNonNull(getClass().getResource("presentation/style.css")).toExternalForm()
-        );
-        scene.getRoot().getStyleClass().add("theme-dark");
+        Parent root = loader.load();
+        Scene scene = new Scene(root, 430, 680);
+        ThemeManager.applyDark(scene, root);
         stage.setScene(scene);
         stage.setTitle("GZAssist");
         stage.setResizable(false);

--- a/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
+++ b/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
@@ -1,6 +1,7 @@
 package br.com.gzlabs.gzassist.presentation;
 
 import br.com.gzlabs.gzassist.core.Mode;
+import br.com.gzlabs.gzassist.util.ThemeManager;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -11,6 +12,9 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
 
 public class HomeController {
 
@@ -67,24 +71,22 @@ public class HomeController {
     }
 
     @FXML
-    protected void onSettingsClick() {
-        try {
-            FXMLLoader loader = new FXMLLoader(getClass().getResource("settings-view.fxml"));
-            Parent root = loader.load();
-            Stage stage = new Stage();
-            stage.setMinWidth(650);
-            stage.setMinHeight(450);
-            stage.initOwner(examQuestionBtn.getScene().getWindow());
-            stage.initModality(Modality.APPLICATION_MODAL);
-            Scene scene = new Scene(root);
-            stage.setScene(scene);
-            stage.setTitle("Settings");
+    protected void onSettingsClick() throws IOException {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("settings-view.fxml"));
+        Parent root = loader.load();
 
-            stage.showAndWait();
-        } catch (Exception e) {
-            LOG.error("Não foi possível abrir configurações", e);
-        }
+        Scene scene = new Scene(root, 650, 450);
+        scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("settings.css")).toExternalForm());
+        ThemeManager.applyDark(scene, root);
+
+        Stage stage = new Stage();
+        stage.setTitle("Settings");
+        stage.setScene(scene);
+        stage.initModality(Modality.APPLICATION_MODAL);
+        stage.initOwner(examQuestionBtn.getScene().getWindow());
+        stage.showAndWait();
     }
+
 
     @FXML
     protected void onExitClick() {

--- a/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
+++ b/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
@@ -18,11 +18,16 @@ public class HomeController {
     private static final String SELECTED_STYLE_CLASS = "selected";
     private Mode selectedMode = Mode.EXAM_QUESTION;
 
-    @FXML private Button examQuestionBtn;
-    @FXML private Button codeExplainBtn;
-    @FXML private Button summarizeBtn;
-    @FXML private Button translateBtn;
-    @FXML private Button autoDetectBtn;
+    @FXML
+    private Button examQuestionBtn;
+    @FXML
+    private Button codeExplainBtn;
+    @FXML
+    private Button summarizeBtn;
+    @FXML
+    private Button translateBtn;
+    @FXML
+    private Button autoDetectBtn;
 
     private Button selectedBtn;
 
@@ -71,8 +76,10 @@ public class HomeController {
             stage.setMinHeight(450);
             stage.initOwner(examQuestionBtn.getScene().getWindow());
             stage.initModality(Modality.APPLICATION_MODAL);
-            stage.setScene(new Scene(root));
+            Scene scene = new Scene(root);
+            stage.setScene(scene);
             stage.setTitle("Settings");
+
             stage.showAndWait();
         } catch (Exception e) {
             LOG.error("Não foi possível abrir configurações", e);

--- a/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
+++ b/src/main/java/br/com/gzlabs/gzassist/presentation/HomeController.java
@@ -71,22 +71,25 @@ public class HomeController {
     }
 
     @FXML
-    protected void onSettingsClick() throws IOException {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource("settings-view.fxml"));
-        Parent root = loader.load();
+    protected void onSettingsClick() {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("settings-view.fxml"));
+            Parent root = loader.load();
 
-        Scene scene = new Scene(root, 650, 450);
-        scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("settings.css")).toExternalForm());
-        ThemeManager.applyDark(scene, root);
+            Scene scene = new Scene(root, 650, 450);
+            scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("settings.css")).toExternalForm());
+            ThemeManager.applyDark(scene, root);
 
-        Stage stage = new Stage();
-        stage.setTitle("Settings");
-        stage.setScene(scene);
-        stage.initModality(Modality.APPLICATION_MODAL);
-        stage.initOwner(examQuestionBtn.getScene().getWindow());
-        stage.showAndWait();
+            Stage stage = new Stage();
+            stage.setTitle("Settings");
+            stage.setScene(scene);
+            stage.initModality(Modality.APPLICATION_MODAL);
+            stage.initOwner(examQuestionBtn.getScene().getWindow());
+            stage.showAndWait();
+        } catch (IOException e) {
+            LOG.error("Failed to open the settings view.", e);
+        }
     }
-
 
     @FXML
     protected void onExitClick() {

--- a/src/main/java/br/com/gzlabs/gzassist/util/ThemeManager.java
+++ b/src/main/java/br/com/gzlabs/gzassist/util/ThemeManager.java
@@ -1,0 +1,21 @@
+package br.com.gzlabs.gzassist.util;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+
+import java.util.Objects;
+
+public class ThemeManager {
+
+    private ThemeManager() {
+    }
+
+    public static void applyDark(Scene scene, Parent root) {
+        scene.getStylesheets().addAll(
+                Objects.requireNonNull(ThemeManager.class.getResource("/br/com/gzlabs/gzassist/presentation/style.css")).toExternalForm(),
+                Objects.requireNonNull(ThemeManager.class.getResource("/br/com/gzlabs/gzassist/presentation/theme-dark.css")).toExternalForm()
+        );
+        root.getStyleClass().add("theme-dark");
+    }
+}
+

--- a/src/main/java/br/com/gzlabs/gzassist/util/ThemeManager.java
+++ b/src/main/java/br/com/gzlabs/gzassist/util/ThemeManager.java
@@ -11,11 +11,20 @@ public class ThemeManager {
     }
 
     public static void applyDark(Scene scene, Parent root) {
+        apply(scene, root, "theme-dark.css", "theme-dark");
+    }
+
+    public static void applyLight(Scene scene, Parent root) {
+        apply(scene, root, "theme-light.css", "theme-light");
+    }
+
+    private static void apply(Scene scene, Parent root, String themeFile, String themeClass) {
+        scene.getStylesheets().clear();
         scene.getStylesheets().addAll(
                 Objects.requireNonNull(ThemeManager.class.getResource("/br/com/gzlabs/gzassist/presentation/style.css")).toExternalForm(),
-                Objects.requireNonNull(ThemeManager.class.getResource("/br/com/gzlabs/gzassist/presentation/theme-dark.css")).toExternalForm()
+                Objects.requireNonNull(ThemeManager.class.getResource("/br/com/gzlabs/gzassist/presentation/" + themeFile)).toExternalForm()
         );
-        root.getStyleClass().add("theme-dark");
+        root.getStyleClass().removeAll("theme-dark", "theme-light");
+        root.getStyleClass().add(themeClass);
     }
 }
-

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/base.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/base.css
@@ -1,0 +1,59 @@
+/* === THEME TOKENS === */
+.theme-dark {
+    -fx-base-bg: #23232A;
+    -fx-text-color: #ECECF1;
+    -fx-subtext-color: #B3B3BE;
+    -fx-border-color: #37384899;
+    -fx-accent-color: #10A37F;
+    -fx-font-family: "Segoe UI Semibold", "Roboto", Arial, sans-serif;
+}
+
+.theme-light {
+    -fx-base-bg: #FFFFFF;
+    -fx-text-color: #23232A;
+    -fx-subtext-color: #555555;
+    -fx-border-color: #DDDDDD;
+    -fx-accent-color: #007ACC;
+    -fx-font-family: "Segoe UI", "Roboto", Arial, sans-serif;
+}
+
+/* === UTILITY CLASSES === */
+.text-center {
+    -fx-alignment: center;
+}
+
+.text-muted {
+    -fx-text-fill: -fx-subtext-color;
+}
+
+.p-1 {
+    -fx-padding: 8;
+}
+
+.p-2 {
+    -fx-padding: 16;
+}
+
+.p-3 {
+    -fx-padding: 24;
+}
+
+.mt-1 {
+    -fx-padding: 8 0 0 0;
+}
+
+.mb-1 {
+    -fx-padding: 0 0 8 0;
+}
+
+.flex-center {
+    -fx-alignment: center;
+}
+
+.btn {
+    -fx-font-size: 14px;
+    -fx-background-radius: 10;
+    -fx-border-radius: 10;
+    -fx-padding: 7 22 7 22;
+    -fx-cursor: hand;
+}

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/settings-view.fxml
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/settings-view.fxml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.geometry.Insets?>
-
 <StackPane xmlns:fx="http://javafx.com/fxml"
            fx:controller="br.com.gzlabs.gzassist.presentation.SettingsController"
-           stylesheets="@style.css"
+           stylesheets="@settings.css"
            styleClass="root-card">
 
     <VBox spacing="30" alignment="TOP_CENTER" maxWidth="800">

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/settings.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/settings.css
@@ -1,0 +1,13 @@
+@import url("style.css");
+
+#settingsTabPane .tab {
+    -fx-padding: 8 14 8 14;
+}
+
+#settingsTabPane .tab .tab-label {
+    -fx-font-size: 13px;
+}
+
+#settingsTabPane .tab-content-area {
+    -fx-padding: 12 0 0 0;
+}

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/settings.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/settings.css
@@ -1,5 +1,3 @@
-@import url("style.css");
-
 #settingsTabPane .tab {
     -fx-padding: 8 14 8 14;
 }

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/style.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/style.css
@@ -1,14 +1,13 @@
+@import url("base.css");
+@import url("theme-dark.css");
+
 .root-card {
-    -fx-background-color: #23232A;
     -fx-border-radius: 18;
     -fx-background-radius: 18;
     -fx-padding: 34 36 34 36;
-    -fx-effect: dropshadow(gaussian, #181a1b, 24, 0.18, 0, 4);
-    -fx-font-family: "Segoe UI Semibold", "Roboto", Arial, sans-serif;
 }
 
 .title {
-    -fx-text-fill: #ECECF1;
     -fx-font-size: 29px;
     -fx-font-weight: bold;
     -fx-font-smoothing-type: lcd;
@@ -16,7 +15,6 @@
 }
 
 .subtitle {
-    -fx-text-fill: #B3B3BE;
     -fx-font-size: 16px;
     -fx-font-smoothing-type: lcd;
 }
@@ -26,18 +24,14 @@
 }
 
 .main-btn {
-    -fx-background-color: linear-gradient(to bottom, #292936, #23232A 80%);
-    -fx-text-fill: #ECECF1;
-    -fx-font-size: 16.5px;
-    -fx-font-family: "Segoe UI Semibold", "Roboto", Arial, sans-serif;
+    -fx-font-size: 17px;
+    -fx-font-family: -fx-font-family;
     -fx-background-radius: 12;
     -fx-border-radius: 12;
-    -fx-border-color: #35363e;
     -fx-border-width: 1.2;
-    -fx-alignment: CENTER;
+    -fx-alignment: center;
     -fx-padding: 0;
     -fx-cursor: hand;
-    -fx-effect: dropshadow(gaussian, #101014, 4,0,0,1.5);
     -fx-min-width: 260;
     -fx-max-width: 380;
     -fx-pref-height: 44;
@@ -45,25 +39,16 @@
 }
 
 .main-btn:hover {
-    -fx-background-color: linear-gradient(to bottom, #363646, #23232A 80%);
-    -fx-border-color: #a7a7b3;
-    -fx-text-fill: #ECECF1;
-    -fx-effect: dropshadow(gaussian, #23232A, 6, 0.11, 0, 1);
+    -fx-opacity: 0.85;
 }
 
 .main-btn:pressed {
-    -fx-background-color: linear-gradient(to bottom, #484857, #31313a 80%);
-    -fx-border-color: #ECECF1;
-    -fx-text-fill: #ECECF1;
-    -fx-effect: dropshadow(gaussian, #32323a, 6, 0.12, 0, 1);
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
 }
 
 .main-btn.selected {
-    -fx-background-color: linear-gradient(to bottom, #fafaff, #f1f1f6 80%);
-    -fx-text-fill: #23232A;
-    -fx-border-color: #ECECF1;
     -fx-font-weight: bold;
-    -fx-effect: dropshadow(gaussian, #bbbbd1, 8, 0.19, 0, 2);
     -fx-scale-x: 1.03;
     -fx-scale-y: 1.08;
     -fx-translate-y: -2;
@@ -76,11 +61,9 @@
 
 .separator .line {
     -fx-border-width: 0 0 1 0;
-    -fx-border-color: #37384899;   /* cinza escuro translúcido */
     -fx-border-insets: 0;
     -fx-border-radius: 2;
 }
-
 
 .history-vbox {
     -fx-padding: 10 0 0 0;
@@ -88,18 +71,10 @@
 }
 
 .history-title {
-    -fx-text-fill: #D1D1E1;
     -fx-font-size: 14px;
     -fx-font-weight: bold;
     -fx-font-smoothing-type: lcd;
     -fx-padding: 6 0 0 0;
-}
-
-.history-item {
-    -fx-text-fill: #B3B3BE;
-    -fx-font-size: 13px;
-    -fx-font-smoothing-type: lcd;
-    -fx-padding: 0 0 0 8;
 }
 
 .footer-hbox {
@@ -107,73 +82,20 @@
 }
 
 .footer-btn {
-    -fx-background-color: #24242c;
-    -fx-text-fill: #ececf1;
     -fx-font-size: 14px;
     -fx-background-radius: 10;
     -fx-border-radius: 10;
-    -fx-border-color: #35363e;
     -fx-border-width: 1;
     -fx-padding: 7 22 7 22;
     -fx-cursor: hand;
-    -fx-effect: dropshadow(gaussian, #101014, 2,0,0,1);
-    -fx-transition: background-color 0.18s, -fx-background-color 0.18s, -fx-text-fill 0.15s;
+    -fx-transition: background-color 0.18s, -fx-text-fill 0.15s;
 }
 
 .footer-btn:hover {
-    -fx-background-color: #373748;
-    -fx-text-fill: #ECECF1;
-    -fx-border-color: #a7a7b3;
+    -fx-opacity: 0.9;
 }
 
 .footer-btn:pressed {
-    -fx-background-color: #464658;
-    -fx-text-fill: #ECECF1;
-    -fx-border-color: #ececf188;
-}
-
-#settingsTabPane {
-    -fx-background-color: #23232A;
-}
-
-#settingsTabPane .tab-header-area {
-    -fx-background-color: #23232A;
-    -fx-border-color: #37384899;
-    -fx-border-width: 0 0 1 0;
-}
-
-#settingsTabPane .tab-header-background {
-    -fx-background-color: #23232A;
-}
-
-#settingsTabPane .tab {
-    -fx-background-color: #23232A;
-    -fx-border-color: transparent;
-    -fx-padding: 8 14 8 14;
-}
-
-#settingsTabPane .tab:hover {
-    -fx-background-color: #2a2a34;
-}
-
-#settingsTabPane .tab:selected {
-    -fx-background-color: #2e2e3a;
-    -fx-border-color: #ECECF1;
-    -fx-border-width: 0 0 2 0;
-}
-
-#settingsTabPane .tab:selected .tab-label {
-    -fx-text-fill: #ECECF1;
-    -fx-font-weight: bold;
-}
-
-#settingsTabPane .tab .tab-label {
-    -fx-text-fill: #B3B3BE;
-    -fx-font-size: 13px;
-    -fx-font-family: "Segoe UI Semibold", "Roboto", sans-serif;
-}
-
-#settingsTabPane .tab-content-area {
-    -fx-background-color: #23232A;
-    -fx-padding: 12 0 0 0;
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
 }

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/style.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/style.css
@@ -1,5 +1,4 @@
 @import url("base.css");
-@import url("theme-dark.css");
 
 .root-card {
     -fx-border-radius: 18;

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
@@ -1,0 +1,97 @@
+@import url("base.css");
+
+/* Root card ----------------------------------------------------------- */
+.theme-dark .root-card,
+.theme-dark.root-card {
+    -fx-background-color: -fx-base-bg;
+    -fx-border-radius: 18;
+    -fx-background-radius: 18;
+    -fx-padding: 34 36 34 36;
+    -fx-font-family: -fx-font-family;
+    -fx-effect: dropshadow(gaussian, rgba(24, 26, 27, 0.7), 24, 0.18, 0, 4);
+}
+
+/* Titles & subtitles -------------------------------------------------- */
+.theme-dark .title,
+.theme-dark.title {
+    -fx-text-fill: -fx-text-color;
+    -fx-font-size: 29px;
+    -fx-font-weight: bold;
+}
+
+.theme-dark .subtitle,
+.theme-dark.subtitle,
+.theme-dark .history-item,
+.theme-dark.history-item {
+    -fx-text-fill: -fx-subtext-color;
+    -fx-font-size: 13px;
+}
+
+/* Main buttons -------------------------------------------------------- */
+.theme-dark .main-btn,
+.theme-dark.main-btn {
+    -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, -fx-base-bg 0%, -fx-base-bg 80%);
+    -fx-text-fill: -fx-text-color;
+    -fx-border-color: derive(-fx-base-bg, 20%);
+    -fx-border-width: 1.2;
+    -fx-background-radius: 12;
+    -fx-border-radius: 12;
+    -fx-effect: dropshadow(gaussian, rgba(16, 16, 20, 0.8), 4, 0, 0, 1.5);
+}
+
+/* Footer buttons ------------------------------------------------------ */
+.theme-dark .footer-btn,
+.theme-dark.footer-btn {
+    -fx-background-color: derive(-fx-base-bg, -5%);
+    -fx-text-fill: -fx-text-color;
+    -fx-border-color: derive(-fx-base-bg, 15%);
+}
+
+/* SETTINGS TABPANE ---------------------------------------------------- */
+.theme-dark #settingsTabPane,
+.theme-dark#settingsTabPane {
+    -fx-background-color: -fx-base-bg;
+}
+
+.theme-dark #settingsTabPane .tab-header-area,
+.theme-dark#settingsTabPane .tab-header-area,
+.theme-dark #settingsTabPane .tab-content-area,
+.theme-dark#settingsTabPane .tab-content-area {
+    -fx-background-color: -fx-base-bg;
+}
+
+.theme-dark #settingsTabPane .tab-header-area,
+.theme-dark#settingsTabPane .tab-header-area {
+    -fx-border-color: -fx-border-color;
+    -fx-border-width: 0 0 1 0;
+}
+
+.theme-dark #settingsTabPane .tab,
+.theme-dark#settingsTabPane .tab {
+    -fx-background-color: -fx-base-bg;
+    -fx-border-color: transparent;
+}
+
+.theme-dark #settingsTabPane .tab:hover,
+.theme-dark#settingsTabPane .tab:hover {
+    -fx-background-color: derive(-fx-base-bg, 10%);
+}
+
+.theme-dark #settingsTabPane .tab:selected,
+.theme-dark#settingsTabPane .tab:selected {
+    -fx-background-color: derive(-fx-base-bg, 20%);
+    -fx-border-color: -fx-text-color;
+    -fx-border-width: 0 0 2 0;
+}
+
+.theme-dark #settingsTabPane .tab .tab-label,
+.theme-dark#settingsTabPane .tab .tab-label {
+    -fx-text-fill: -fx-subtext-color;
+    -fx-font-size: 13px;
+}
+
+.theme-dark #settingsTabPane .tab:selected .tab-label,
+.theme-dark#settingsTabPane .tab:selected .tab-label {
+    -fx-text-fill: -fx-text-color;
+    -fx-font-weight: bold;
+}

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
@@ -1,6 +1,6 @@
 @import url("base.css");
 
-/* Root card ----------------------------------------------------------- */
+/* Root card */
 .theme-dark .root-card,
 .theme-dark.root-card {
     -fx-background-color: -fx-base-bg;
@@ -11,7 +11,7 @@
     -fx-effect: dropshadow(gaussian, rgba(24, 26, 27, 0.7), 24, 0.18, 0, 4);
 }
 
-/* Titles & subtitles -------------------------------------------------- */
+/* Titles & subtitles */
 .theme-dark .title,
 .theme-dark.title {
     -fx-text-fill: -fx-text-color;
@@ -27,7 +27,7 @@
     -fx-font-size: 13px;
 }
 
-/* Main buttons -------------------------------------------------------- */
+/* Main buttons */
 .theme-dark .main-btn,
 .theme-dark.main-btn {
     -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, -fx-base-bg 0%, -fx-base-bg 80%);
@@ -39,7 +39,7 @@
     -fx-effect: dropshadow(gaussian, rgba(16, 16, 20, 0.8), 4, 0, 0, 1.5);
 }
 
-/* Footer buttons ------------------------------------------------------ */
+/* Footer buttons */
 .theme-dark .footer-btn,
 .theme-dark.footer-btn {
     -fx-background-color: derive(-fx-base-bg, -5%);
@@ -47,7 +47,7 @@
     -fx-border-color: derive(-fx-base-bg, 15%);
 }
 
-/* SETTINGS TABPANE ---------------------------------------------------- */
+/* SETTINGS TABPANE */
 .theme-dark #settingsTabPane,
 .theme-dark#settingsTabPane {
     -fx-background-color: -fx-base-bg;
@@ -62,7 +62,7 @@
 
 .theme-dark #settingsTabPane .tab-header-area,
 .theme-dark#settingsTabPane .tab-header-area {
-    -fx-border-color: -fx-border-color;
+    -fx-border-color: #37384899; /* <- CORRIGIDO */
     -fx-border-width: 0 0 1 0;
 }
 

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
@@ -57,50 +57,41 @@
     -fx-border-color: transparent;
 }
 
-.theme-dark #settingsTabPane,
-.theme-dark#settingsTabPane {
+.theme-dark #settingsTabPane {
     -fx-background-color: -fx-base-bg;
 }
 
 .theme-dark #settingsTabPane .tab-header-area,
-.theme-dark#settingsTabPane .tab-header-area,
-.theme-dark #settingsTabPane .tab-content-area,
-.theme-dark#settingsTabPane .tab-content-area {
+.theme-dark #settingsTabPane .tab-content-area {
     -fx-background-color: -fx-base-bg;
 }
 
-.theme-dark #settingsTabPane .tab-header-area,
-.theme-dark#settingsTabPane .tab-header-area {
+.theme-dark #settingsTabPane .tab-header-area {
     -fx-border-color: #37384899;
     -fx-border-width: 0 0 1 0;
 }
 
-.theme-dark #settingsTabPane .tab,
-.theme-dark#settingsTabPane .tab {
+.theme-dark #settingsTabPane .tab {
     -fx-background-color: -fx-base-bg;
     -fx-border-color: transparent;
 }
 
-.theme-dark #settingsTabPane .tab:hover,
-.theme-dark#settingsTabPane .tab:hover {
+.theme-dark #settingsTabPane .tab:hover {
     -fx-background-color: derive(-fx-base-bg, 10%);
 }
 
-.theme-dark #settingsTabPane .tab:selected,
-.theme-dark#settingsTabPane .tab:selected {
+.theme-dark #settingsTabPane .tab:selected {
     -fx-background-color: derive(-fx-base-bg, 20%);
     -fx-border-color: -fx-text-color;
     -fx-border-width: 0 0 2 0;
 }
 
-.theme-dark #settingsTabPane .tab .tab-label,
-.theme-dark#settingsTabPane .tab .tab-label {
+.theme-dark #settingsTabPane .tab .tab-label {
     -fx-text-fill: -fx-subtext-color;
     -fx-font-size: 13px;
 }
 
-.theme-dark #settingsTabPane .tab:selected .tab-label,
-.theme-dark#settingsTabPane .tab:selected .tab-label {
+.theme-dark #settingsTabPane .tab:selected .tab-label {
     -fx-text-fill: -fx-text-color;
     -fx-font-weight: bold;
 }

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-dark.css
@@ -49,6 +49,15 @@
 
 /* SETTINGS TABPANE */
 .theme-dark #settingsTabPane,
+.theme-dark #settingsTabPane .tab-header-background {
+    -fx-background-color: -fx-base-bg;
+    -fx-opacity: 1;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-border-color: transparent;
+}
+
+.theme-dark #settingsTabPane,
 .theme-dark#settingsTabPane {
     -fx-background-color: -fx-base-bg;
 }
@@ -62,7 +71,7 @@
 
 .theme-dark #settingsTabPane .tab-header-area,
 .theme-dark#settingsTabPane .tab-header-area {
-    -fx-border-color: #37384899; /* <- CORRIGIDO */
+    -fx-border-color: #37384899;
     -fx-border-width: 0 0 1 0;
 }
 

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
@@ -8,17 +8,23 @@
     -fx-background-radius: 18;
     -fx-padding: 34 36 34 36;
     -fx-font-family: -fx-font-family;
-    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.1), 8, 0, 0, 2);
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.10), 24, 0.18, 0, 4);
 }
 
 /* Titles & subtitles -------------------------------------------------- */
 .theme-light .title,
-.theme-light.title,
+.theme-light.title {
+    -fx-text-fill: -fx-text-color;
+    -fx-font-size: 29px;
+    -fx-font-weight: bold;
+}
+
 .theme-light .subtitle,
 .theme-light.subtitle,
 .theme-light .history-item,
 .theme-light.history-item {
-    -fx-text-fill: -fx-text-color;
+    -fx-text-fill: -fx-subtext-color;
+    -fx-font-size: 13px;
 }
 
 /* Main buttons -------------------------------------------------------- */
@@ -26,60 +32,63 @@
 .theme-light.main-btn {
     -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, -fx-base-bg 0%, -fx-base-bg 80%);
     -fx-text-fill: -fx-text-color;
-    -fx-border-color: derive(-fx-border-color, -10%);
+    -fx-border-color: derive(-fx-base-bg, -20%);
+    -fx-border-width: 1.2;
+    -fx-background-radius: 12;
+    -fx-border-radius: 12;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.08), 4, 0, 0, 1.5);
 }
 
 /* Footer buttons ------------------------------------------------------ */
 .theme-light .footer-btn,
 .theme-light.footer-btn {
-    -fx-background-color: derive(-fx-base-bg, -10%);
+    -fx-background-color: derive(-fx-base-bg, -5%);
     -fx-text-fill: -fx-text-color;
-    -fx-border-color: derive(-fx-border-color, -20%);
+    -fx-border-color: derive(-fx-base-bg, -20%);
 }
 
 /* SETTINGS TABPANE ---------------------------------------------------- */
 .theme-light #settingsTabPane,
-.theme-light#settingsTabPane {
+.theme-light #settingsTabPane .tab-header-background {
     -fx-background-color: -fx-base-bg;
+    -fx-opacity: 1;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-border-color: transparent;
 }
 
 .theme-light #settingsTabPane .tab-header-area,
-.theme-light#settingsTabPane .tab-header-area,
-.theme-light #settingsTabPane .tab-content-area,
-.theme-light#settingsTabPane .tab-content-area {
+.theme-light #settingsTabPane .tab-content-area {
     -fx-background-color: -fx-base-bg;
 }
 
-.theme-light #settingsTabPane .tab-header-area,
-.theme-light#settingsTabPane .tab-header-area {
-    -fx-border-color: #DDDDDD; /* ← Corrigido aqui */
+.theme-light #settingsTabPane .tab-header-area {
+    -fx-border-color: #DDDDDD;
     -fx-border-width: 0 0 1 0;
 }
 
 .theme-light #settingsTabPane .tab,
-.theme-light#settingsTabPane .tab {
+.theme-light #settingsTabPane .tab {
     -fx-background-color: -fx-base-bg;
+    -fx-border-color: transparent;
 }
 
-.theme-light #settingsTabPane .tab:hover,
-.theme-light#settingsTabPane .tab:hover {
-    -fx-background-color: derive(-fx-base-bg, -5%);
+.theme-light #settingsTabPane .tab:hover {
+    -fx-background-color: derive(-fx-base-bg, -3%);
 }
 
-.theme-light #settingsTabPane .tab:selected,
-.theme-light#settingsTabPane .tab:selected {
-    -fx-background-color: derive(-fx-base-bg, -15%);
+.theme-light #settingsTabPane .tab:selected {
+    -fx-background-color: derive(-fx-base-bg, -6%);
     -fx-border-color: -fx-text-color;
     -fx-border-width: 0 0 2 0;
 }
 
-.theme-light #settingsTabPane .tab .tab-label,
-.theme-light#settingsTabPane .tab .tab-label {
+.theme-light #settingsTabPane .tab .tab-label {
     -fx-text-fill: -fx-subtext-color;
+    -fx-font-size: 13px;
 }
 
-.theme-light #settingsTabPane .tab:selected .tab-label,
-.theme-light#settingsTabPane .tab:selected .tab-label {
+.theme-light #settingsTabPane .tab:selected .tab-label {
     -fx-text-fill: -fx-text-color;
     -fx-font-weight: bold;
 }

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
@@ -52,7 +52,7 @@
 
 .theme-light #settingsTabPane .tab-header-area,
 .theme-light#settingsTabPane .tab-header-area {
-    -fx-border-color: -fx-border-color;
+    -fx-border-color: #DDDDDD; /* ← Corrigido aqui */
     -fx-border-width: 0 0 1 0;
 }
 

--- a/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
+++ b/src/main/resources/br/com/gzlabs/gzassist/presentation/theme-light.css
@@ -1,0 +1,85 @@
+@import url("base.css");
+
+/* Root card ----------------------------------------------------------- */
+.theme-light .root-card,
+.theme-light.root-card {
+    -fx-background-color: -fx-base-bg;
+    -fx-border-radius: 18;
+    -fx-background-radius: 18;
+    -fx-padding: 34 36 34 36;
+    -fx-font-family: -fx-font-family;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.1), 8, 0, 0, 2);
+}
+
+/* Titles & subtitles -------------------------------------------------- */
+.theme-light .title,
+.theme-light.title,
+.theme-light .subtitle,
+.theme-light.subtitle,
+.theme-light .history-item,
+.theme-light.history-item {
+    -fx-text-fill: -fx-text-color;
+}
+
+/* Main buttons -------------------------------------------------------- */
+.theme-light .main-btn,
+.theme-light.main-btn {
+    -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, -fx-base-bg 0%, -fx-base-bg 80%);
+    -fx-text-fill: -fx-text-color;
+    -fx-border-color: derive(-fx-border-color, -10%);
+}
+
+/* Footer buttons ------------------------------------------------------ */
+.theme-light .footer-btn,
+.theme-light.footer-btn {
+    -fx-background-color: derive(-fx-base-bg, -10%);
+    -fx-text-fill: -fx-text-color;
+    -fx-border-color: derive(-fx-border-color, -20%);
+}
+
+/* SETTINGS TABPANE ---------------------------------------------------- */
+.theme-light #settingsTabPane,
+.theme-light#settingsTabPane {
+    -fx-background-color: -fx-base-bg;
+}
+
+.theme-light #settingsTabPane .tab-header-area,
+.theme-light#settingsTabPane .tab-header-area,
+.theme-light #settingsTabPane .tab-content-area,
+.theme-light#settingsTabPane .tab-content-area {
+    -fx-background-color: -fx-base-bg;
+}
+
+.theme-light #settingsTabPane .tab-header-area,
+.theme-light#settingsTabPane .tab-header-area {
+    -fx-border-color: -fx-border-color;
+    -fx-border-width: 0 0 1 0;
+}
+
+.theme-light #settingsTabPane .tab,
+.theme-light#settingsTabPane .tab {
+    -fx-background-color: -fx-base-bg;
+}
+
+.theme-light #settingsTabPane .tab:hover,
+.theme-light#settingsTabPane .tab:hover {
+    -fx-background-color: derive(-fx-base-bg, -5%);
+}
+
+.theme-light #settingsTabPane .tab:selected,
+.theme-light#settingsTabPane .tab:selected {
+    -fx-background-color: derive(-fx-base-bg, -15%);
+    -fx-border-color: -fx-text-color;
+    -fx-border-width: 0 0 2 0;
+}
+
+.theme-light #settingsTabPane .tab .tab-label,
+.theme-light#settingsTabPane .tab .tab-label {
+    -fx-text-fill: -fx-subtext-color;
+}
+
+.theme-light #settingsTabPane .tab:selected .tab-label,
+.theme-light#settingsTabPane .tab:selected .tab-label {
+    -fx-text-fill: -fx-text-color;
+    -fx-font-weight: bold;
+}


### PR DESCRIPTION
---

### Summary of Changes

This pull request introduces significant updates to the theme handling and UI styling, including:

- **Dynamic theme support**: Added ability to switch between light and dark themes dynamically.
- **Styling improvements**:
  - Enhanced **light theme** for improved readability and consistency, including updates to shadows, padding, fonts, and borders.
  - Improved **dark theme** styles, particularly in the settings tabpane, with better background, opacity, and border configurations.
- **Centralized theme management**:
  - Introduced a `ThemeManager` utility to streamline theme application and ensure consistency.
  - Refactored related components like `onSettingsClick` and `Main` to utilize this centralized utility.
- **UI customization**: Separated theme-specific stylesheets (`theme-dark.css` and `theme-light.css`) for better maintenance and customization. A shared `base.css` handles common styling.

### Technical Details

The theme handling now includes:
- A shared `apply` method for consistent style management.
- Support for reducing code duplication across themes.

Default theme is set as dark mode in `Main.java`.

### Checklist

- [x] Added/updated documentation.
- [x] Tested on multiple devices/browsers.
- [x] Verified backward compatibility.
- [x] Added test cases to validate new functionality. 

---